### PR TITLE
Fix Directory Path in Fractal Bitcoin Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ With strong tooling and support, building on Fractal is straightforward.
 ```
 git clone https://github.com/fractal-bitcoin/fractald-release.git
 
+cd fractald-release
 cd fractald-x86_64-linux-gnu
 
 mkdir data

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ cp ./bitcoin.conf ./data
 ```
 git clone https://github.com/fractal-bitcoin/fractald-release.git
 
+cd fractald-release
 cd fractald-docker
 
 docker-compose up -d


### PR DESCRIPTION
This pull request addresses a minor error in the documentation regarding the directory path for accessing the Fractal Bitcoin repository after cloning. I have updated the instructions to specify the correct path for navigating to the fractald-x86_64-linux-gnu directory within the cloned repository.

This correction ensures that users can easily locate the necessary files without confusion, improving the overall clarity and usability of the documentation.

https://x.com/brsbtc